### PR TITLE
docs: add the 2-minute demo video to the top of the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,15 +21,9 @@ keeps it honest — into *your* project. Then it proves the result sound before 
 
 ## Watch it work
 
-VARIANT-BARE
+[![Watch the 2-minute demo](https://img.youtube.com/vi/qrY74MvaVoU/maxresdefault.jpg)](https://www.youtube.com/watch?v=qrY74MvaVoU)
 
-https://github.com/RonMizrahi/sdlc-graph-engineering/releases/download/demo-assets/sdlc-graph-demo-2min.mp4
-
-VARIANT-IMG
-
-![demo](https://github.com/RonMizrahi/sdlc-graph-engineering/releases/download/demo-assets/sdlc-graph-demo-2min.mp4)
-
-Two minutes, no audio. Not seeing a player? [Watch it on YouTube](https://www.youtube.com/watch?v=qrY74MvaVoU).
+Two minutes, no audio. Click to play on YouTube.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,14 @@ keeps it honest — into *your* project. Then it proves the result sound before 
 
 ---
 
+## Watch it work
+
+<video src="https://github.com/RonMizrahi/sdlc-graph-engineering/releases/download/demo-assets/sdlc-graph-demo-2min.mp4" controls muted playsinline width="100%"></video>
+
+Two minutes, no audio. Not seeing a player? [Watch it on YouTube](https://www.youtube.com/watch?v=qrY74MvaVoU).
+
+---
+
 ## Example output
 
 Example — superpowers as a graph (by [obra/superpowers](https://github.com/obra/superpowers)),

--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ keeps it honest — into *your* project. Then it proves the result sound before 
 
 ## Watch it work
 
-[![Watch the 2-minute demo](https://img.youtube.com/vi/qrY74MvaVoU/maxresdefault.jpg)](https://www.youtube.com/watch?v=qrY74MvaVoU)
+https://github.com/user-attachments/assets/c717c1dc-214d-4b6b-8ad5-55dd5107baf1
 
-Two minutes, no audio. Click to play on YouTube.
+Two minutes, no audio. Not seeing a player? [Watch it on YouTube](https://www.youtube.com/watch?v=qrY74MvaVoU).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # SDLC Graph Engineering
 
+https://github.com/user-attachments/assets/c717c1dc-214d-4b6b-8ad5-55dd5107baf1
+
+*Two minutes, no audio. Not seeing a player? [Watch it on YouTube](https://www.youtube.com/watch?v=qrY74MvaVoU).*
+
 **Turn the process you already have into a graph a machine can actually execute.**
 
 A [Claude Code](https://code.claude.com) plugin that takes your existing process — a set of skills, a
@@ -16,14 +20,6 @@ keeps it honest — into *your* project. Then it proves the result sound before 
 &nbsp;![Zero dependencies](https://img.shields.io/badge/dependencies-0-6a787c)
 
 ![A linear SDLC — brainstorm, spec, plan, implement, review, release — transformed by graph engineering into an executable graph with typed nodes, guarded edges, bounded loops, durable state, and three typed terminal states: merge, publish, discard](docs/assets/traditional-vs-graph-sdlc.png)
-
----
-
-## Watch it work
-
-https://github.com/user-attachments/assets/c717c1dc-214d-4b6b-8ad5-55dd5107baf1
-
-Two minutes, no audio. Not seeing a player? [Watch it on YouTube](https://www.youtube.com/watch?v=qrY74MvaVoU).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,13 @@ keeps it honest — into *your* project. Then it proves the result sound before 
 
 ## Watch it work
 
-<video src="https://github.com/RonMizrahi/sdlc-graph-engineering/releases/download/demo-assets/sdlc-graph-demo-2min.mp4" controls muted playsinline width="100%"></video>
+VARIANT-BARE
+
+https://github.com/RonMizrahi/sdlc-graph-engineering/releases/download/demo-assets/sdlc-graph-demo-2min.mp4
+
+VARIANT-IMG
+
+![demo](https://github.com/RonMizrahi/sdlc-graph-engineering/releases/download/demo-assets/sdlc-graph-demo-2min.mp4)
 
 Two minutes, no audio. Not seeing a player? [Watch it on YouTube](https://www.youtube.com/watch?v=qrY74MvaVoU).
 


### PR DESCRIPTION
Adds the 2-minute demo as an inline player at the top of the root README, directly under the H1 and above the tagline.

## How the video is hosted

GitHub only renders a player for videos on its **attachment** hosts. Verified on this branch, all three alternatives fail:

| approach | result |
|---|---|
| commit to `docs/assets/` + `<video src=raw.githubusercontent…>` | blocked — CSP `media-src` violation, and `<video>` is stripped by the README sanitizer |
| release asset, bare URL | renders as a plain link |
| release asset, `![](…)` | renders as a broken `<img src=…mp4>` |
| **issue attachment, bare URL** | **plays** — 1920×942, 118s |

So the file lives as an attachment on #5. **Do not delete that issue** — the attachment URL dies with it. Closing it is fine; only deletion breaks the video.

A YouTube link sits under the player as the fallback for npm, mirrors, and local Markdown previews, where GitHub's player does not exist.

## Verification

Rendered branch page checked in a real browser: `<video>` present, `readyState: 4`, no error, correct dimensions and duration, and ordered after the H1 / before the tagline.

## Note

An unused `demo-assets` release was created while testing the release-asset route. It can be removed with `gh release delete demo-assets --cleanup-tag`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019RsytKtzWuL5xgQfd6meQY