### PR TITLE
docs: clarify the demo shows my own graph, not a bundled one

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 https://github.com/user-attachments/assets/c717c1dc-214d-4b6b-8ad5-55dd5107baf1
 
+What you are watching is *my* graph running — not a graph this plugin ships. There is no bundled
+graph. The plugin turns **your** skills and process into one, and yours will look nothing like this.
+
 *Two minutes, no audio. Not seeing a player? [Watch it on YouTube](https://www.youtube.com/watch?v=qrY74MvaVoU).*
 
 **Turn the process you already have into a graph a machine can actually execute.**


### PR DESCRIPTION
Follow-up to #6. Adds two lines under the demo video at the top of the README, so a first-time reader does not mistake the recording for something the plugin ships:

> What you are watching is *my* graph running — not a graph this plugin ships. There is no bundled graph. The plugin turns **your** skills and process into one, and yours will look nothing like this.

This echoes the existing line in the "Example output" section ("*Your* graph will look nothing like this one"), reinforcing the same point at the top of the page where most readers stop.

README-only; no skill, manifest, or version change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019RsytKtzWuL5xgQfd6meQY